### PR TITLE
Simplify SDK conversion: Python 3.12+ support & batch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Download this repo, extract it in the newly created folder, and put your clean N
 
 Copy the `include` folder of the Nitro SDK 3.0 and Nitro System in the template root folder.
 
-Run the conversion script `convert_sdk.py` (preferably using the command `py -3 convert_sdk.py`) and wait until the process has finished.
+Run the conversion script by either double-clicking `run_convert_sdk.bat` (windows only) or executing `convert_sdk.py` directly (preferably using the command `py -3 convert_sdk.py`). Wait for the process to complete.
 
 Download the NSMB-Code-Reference repo and extract `symbols7.x`, `symbols9.x` and the `include` folder in the template root directory.
 

--- a/convert_sdk.py
+++ b/convert_sdk.py
@@ -7,7 +7,8 @@
 import re
 import glob
 import sys
-import distutils.dir_util
+import os.path
+
 
 # Headers to ignore the global to local header change
 libHeaders = ['stdio.h', 'stdarg.h']
@@ -377,3 +378,10 @@ __bgcnt_decl(GXBg2ControlLargeBmp,
 
 	with open(filename, 'w') as f:
 		f.writelines(new_lines)
+
+
+if not os.path.isfile("./include/nitro.h"):
+	print("WARNING: NITRO-SDK was not found in include directory")
+
+if not os.path.isfile("./include/nnsys.h"):
+	print("WARNING: NITRO-System was not found in include directory")

--- a/run_convert_sdk.bat
+++ b/run_convert_sdk.bat
@@ -1,0 +1,21 @@
+@echo off
+setlocal
+
+rem Possible python aliases
+set INTERPRETERS=py "py -3" python py3 python3
+
+set SCRIPT=convert_sdk.py
+
+for %%I in (%INTERPRETERS%) do (
+    where %%I >nul 2>nul
+    if not errorlevel 1 (
+        echo Running with: %%I
+        %%I %SCRIPT%
+	pause
+        exit /b
+    )
+)
+
+echo Error: Python is not installed.
+pause
+exit /b 1

--- a/source/endingscript.cpp
+++ b/source/endingscript.cpp
@@ -1,4 +1,4 @@
-#include "nsmb.hpp"
+#include <nsmb.hpp>
 
 
 /*
@@ -32,7 +32,7 @@
 */
 
 ncp_over(0x020EA678, 8)
-static constexpr End::ScriptEntry script[] = {
+static constexpr End::ScriptEntry Script[] = {
 	
 	// Page 0
 	{"abcdefg"end,				0,	75, End::ScriptEntry::Red,	false},

--- a/source/example.cpp
+++ b/source/example.cpp
@@ -1,17 +1,17 @@
-#include "nsmb.hpp"
+#include <nsmb.hpp>
 
 
 // Replaces the Stage::collectCoin function to not do anything
 
 ncp_jump(0x02020354)
-NTR_NAKED void replaceCollectCoin() {asm(R"(
+NTR_NAKED static void replaceCollectCoin() {asm(R"(
 	bx		lr					@ Return
 )");}
 
 // Hooks into Goomba::updateBahp to set his velocity.y to 4.0fx instead of the function argument
 
 ncp_jump(0x020E2408, 10)
-NTR_NAKED void higherGoombaBahp() {asm(R"(
+NTR_NAKED static void higherGoombaBahp() {asm(R"(
 	ldr		r1, =0x4000
 	cmp		r2, #0				@ Replaced instruction
 	b		0x020E2408 + 4		@ Branch back
@@ -42,3 +42,8 @@ const SpawnItem brickSpawnItems[16] = {
 	SpawnItem::None,
 	SpawnItem::None
 };
+
+// Replaces worldmap walk particle IDs
+
+ncp_over(0x20e93ec,8)
+static const u32 newWMWalkParticleIDs[2] = { 5, 5 }; // { normal, mini }

--- a/source/instantboot.cpp
+++ b/source/instantboot.cpp
@@ -1,4 +1,4 @@
-#include "nsmb.hpp"
+#include <nsmb.hpp>
 
 
 /*


### PR DESCRIPTION
- Removes useless import of the deprecated distutils module
- Added a warning if Nitro-SDK or Nitro-System aren't in the include folder
- Introduced a batch script that tries to run the conversion script with the various python command aliases (py, py3, python, etc)
- Updated example code to follow new reference conventions